### PR TITLE
Update builder.rb

### DIFF
--- a/lib/report_builder/builder.rb
+++ b/lib/report_builder/builder.rb
@@ -80,6 +80,11 @@ module ReportBuilder
         raise "Error:: No file(s) found at #{input_path}" if files.empty?
         groups << {'features' => get_features(files)}
       end
+      groups.each do |this_group|
+        this_group['features'].each do |feature|
+          feature['elements'] = feature['elements'].sort_by { |v| v['line']}
+        end
+      end
       groups
     end
 


### PR DESCRIPTION
Reports built from json files generated by `parallel_tests` don't sort the scenarios by example. This change will sort each feature file by line number for easier readability.